### PR TITLE
Fix division by zero in fresnel function at grazing incidence and TIR

### DIFF
--- a/src/optics_functions.jl
+++ b/src/optics_functions.jl
@@ -2,18 +2,63 @@
     fresnel(θ, n1, n2)
 
 Calculate the reflectance for s-polarized and p-polarized light
-given the incidence angle `θ` and indices of refraction 
+given the incidence angle `θ` (in radians) and indices of refraction
 of two media `n1` and `n2` at a plane interface.
+
+Returns `(Rs, Rp)` where `Rs` is s-polarized reflectance and `Rp` is p-polarized reflectance.
+
+The Fresnel equations for reflectance are:
+
+```math
+R_s = \\left| \\frac{n_1 \\cos\\theta_i - n_2 \\cos\\theta_t}{n_1 \\cos\\theta_i + n_2 \\cos\\theta_t} \\right|^2
+```
+
+```math
+R_p = \\left| \\frac{n_2 \\cos\\theta_i - n_1 \\cos\\theta_t}{n_2 \\cos\\theta_i + n_1 \\cos\\theta_t} \\right|^2
+```
+
+where ``\\theta_t`` is the transmitted angle given by Snell's law:
+``n_1 \\sin\\theta_i = n_2 \\sin\\theta_t``.
+
+Special cases:
+- At grazing incidence (θ → π/2), returns `(1.0, 1.0)`
+- For total internal reflection (when `n1 > n2` and `θ > θ_critical`), returns `(1.0, 1.0)`
 
 [Fresnel equations](https://en.wikipedia.org/wiki/Fresnel_equations)
 """
 function fresnel(θ, n1, n2)
+    cosθ = cos(θ)
+    sinθ = sin(θ)
 
-    α = √(1 - (n1 * sin(θ) / n2)^2) / cos(θ)
-    β = n2 / n1
+    # Handle grazing incidence (cos(θ) ≈ 0)
+    if abs(cosθ) < eps(Float64)
+        return (1.0, 1.0)
+    end
 
-    Rs = abs2((1/β - α) / (1/β + α))
-    Rp = abs2((α - β) / (α + β))
+    # Check for total internal reflection
+    sin_ratio = n1 * sinθ / n2
+    sin_ratio_sq = sin_ratio^2
+
+    if sin_ratio_sq > 1.0
+        # Total internal reflection: all light is reflected
+        return (1.0, 1.0)
+    end
+
+    cosθt = √(1 - sin_ratio_sq)  # cos of transmitted angle
+
+    # Standard Fresnel equations
+    # Rs = |( n1 cosθ - n2 cosθt ) / ( n1 cosθ + n2 cosθt )|²
+    # Rp = |( n2 cosθ - n1 cosθt ) / ( n2 cosθ + n1 cosθt )|²
+    n1_cosθ = n1 * cosθ
+    n2_cosθt = n2 * cosθt
+    n2_cosθ = n2 * cosθ
+    n1_cosθt = n1 * cosθt
+
+    rs = (n1_cosθ - n2_cosθt) / (n1_cosθ + n2_cosθt)
+    rp = (n2_cosθ - n1_cosθt) / (n2_cosθ + n1_cosθt)
+
+    Rs = abs2(rs)
+    Rp = abs2(rp)
 
     return Rs, Rp
 end

--- a/test/optics_functions.jl
+++ b/test/optics_functions.jl
@@ -4,18 +4,53 @@
 
     θ = 0.0
     Rs, Rp = fresnel(θ, n1, n2)
-    
-    @test Rs ≈ Rp  # expected reflectance for s-polarized light
+
+    @test Rs ≈ Rp  # at normal incidence, s and p are equal
 
     θ = π / 4
     Rs, Rp = fresnel(θ, n1, n2)
 
-    @test Rp ≈ Rs^2  # expected reflectance for s-polarized light
+    @test Rp ≈ Rs^2  # relationship at 45 degrees
 
     θB = atan(n2 / n1)  # Brewster angle
     Rs, Rp = fresnel(θB, n1, n2)
-    @test Rp ≈ 0.0  # p-polarized reflectance vanishes at Brewster's angle
+    @test Rp ≈ 0.0 atol=1e-10  # p-polarized reflectance vanishes at Brewster's angle
     @test Rs > 0.0  # s-polarized reflectance remains nonzero
+
+    # Test grazing incidence (θ → π/2)
+    θ_grazing = π/2
+    Rs, Rp = fresnel(θ_grazing, n1, n2)
+    @test Rs == 1.0  # total reflection at grazing incidence
+    @test Rp == 1.0
+
+    # Test near-grazing incidence (approaches 1.0 but computed normally)
+    θ_near_grazing = π/2 - 1e-10
+    Rs, Rp = fresnel(θ_near_grazing, n1, n2)
+    @test Rs ≈ 1.0 atol=1e-8
+    @test Rp ≈ 1.0 atol=1e-8
+
+    # Test total internal reflection (n1 > n2, θ > critical angle)
+    n1_tir = 1.5  # glass
+    n2_tir = 1.0  # air
+    θ_critical = asin(n2_tir / n1_tir)  # critical angle ≈ 41.8°
+
+    # Below critical angle: partial reflection
+    θ_below = θ_critical - 0.1
+    Rs, Rp = fresnel(θ_below, n1_tir, n2_tir)
+    @test Rs < 1.0
+    @test Rp < 1.0
+
+    # Above critical angle: total internal reflection
+    θ_above = θ_critical + 0.1
+    Rs, Rp = fresnel(θ_above, n1_tir, n2_tir)
+    @test Rs == 1.0
+    @test Rp == 1.0
+
+    # Well above critical angle
+    θ_well_above = π/3  # 60°, well above ~41.8° critical angle
+    Rs, Rp = fresnel(θ_well_above, n1_tir, n2_tir)
+    @test Rs == 1.0
+    @test Rp == 1.0
 end
 
 @testset "stopband" begin


### PR DESCRIPTION
## Summary
- Add check for grazing incidence (cos(θ) ≈ 0) to avoid division by zero
- Add check for total internal reflection when sin²(θ) > (n2/n1)²
- Rewrite using standard Fresnel equation form for clarity
- Add comprehensive tests for edge cases
- Expand docstring with analytical expressions

Closes #44

## Test plan
- [x] Existing fresnel tests pass
- [x] New edge case tests added for grazing incidence
- [x] New edge case tests added for total internal reflection
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)