### PR TITLE
docs: fix invalid @ref to fresnel_amplitude

### DIFF
--- a/src/optics_functions.jl
+++ b/src/optics_functions.jl
@@ -137,7 +137,7 @@ d = λ / (4 * n_film)  # quarter-wave thickness
 Rs, Rp, Ts, Tp = airy(n_air, n_film, n_glass, d, λ)
 ```
 
-See also: [`fresnel`](@ref), [`fresnel_amplitude`](@ref)
+See also: [`fresnel`](@ref), [`fresnel_coefficients`](@ref)
 """
 function airy(n0, nf, ns, d, λ; θ=0.0)
     sinθ = sin(θ)


### PR DESCRIPTION
## Summary
- Fix invalid `@ref` in `airy` docstring: `fresnel_amplitude` → `fresnel_coefficients`

This was causing the docs build to fail with:
```
Error: Cannot resolve @ref for md"[`fresnel_amplitude`](@ref)" in docs/src/lib/public.md.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)