### PR TITLE
Make Layer broadcast as a scalar (Base.broadcastable)

### DIFF
--- a/src/layer.jl
+++ b/src/layer.jl
@@ -59,6 +59,21 @@ end
 Layer(material::RefractiveMaterial, thickness::Real) = Layer(refractive_index(material), thickness)
 Layer(λs::AbstractVector, dispersion::AbstractVector, extinction::AbstractVector, thickness::Real) = Layer(refractive_index(λs, dispersion, extinction), thickness)
 
+"""
+    Base.broadcastable(layer::Layer)
+
+Treat a single `Layer` as a scalar under broadcasting so helpers can be broadcast
+over one layer across many wavelengths without an explicit `Ref`, e.g.
+`get_refractive_indices.(layer, λs)`. Without this, broadcasting a bare `Layer`
+hits Julia's `collect`-based fallback and throws a confusing
+`MethodError: no method matching length(::Layer)`.
+
+A `Vector{Layer}` stack still broadcasts element-wise, which is the desired
+behavior for per-layer operations. For threaded wavelength/angle/thickness sweeps,
+prefer the dedicated `sweep_angle` / `sweep_thickness` API.
+"""
+Base.broadcastable(layer::Layer) = Ref(layer)
+
 # Anisotropic constructor: three dispersion functions for nx, ny, nz
 """
     Layer(nx, ny, nz, thickness; euler=(0,0,0))

--- a/test/layer.jl
+++ b/test/layer.jl
@@ -380,6 +380,24 @@ end
     @test get_euler_angles(iso_layer) == (0.0, 0.0, 0.0)
 end
 
+@testset "broadcastable Layer" begin
+    layer = Layer(λ -> 1.5 + 0.0im, 0.1)
+    λs = [1.0, 1.1, 1.2]
+
+    # A single Layer is treated as a scalar under broadcasting
+    @test Base.broadcastable(layer) isa Base.RefValue
+
+    # Broadcasting a helper over one layer across many λ works without Ref
+    # (previously threw MethodError: no method matching length(::Layer))
+    bare = get_refractive_indices.(layer, λs)
+    @test bare == get_refractive_indices.(Ref(layer), λs)
+    @test length(bare) == length(λs)
+
+    # A Vector{Layer} still broadcasts element-wise
+    layers = [Layer(λ -> 1.0, 0.1), Layer(λ -> 2.0, 0.2)]
+    @test getfield.(layers, :thickness) == [0.1, 0.2]
+end
+
 @testset "euler_rotation_matrix" begin
     # Identity rotation (no angles)
     R0 = euler_rotation_matrix(0.0, 0.0, 0.0)


### PR DESCRIPTION
Closes #85.

## What

Adds `Base.broadcastable(layer::Layer) = Ref(layer)` so a single `Layer` is treated as a scalar under broadcasting.

## Why

Broadcasting a helper over one layer across many wavelengths — e.g. `get_refractive_indices.(layer, λs)` — previously hit Julia's `collect`-based broadcast fallback and threw a confusing `MethodError: no method matching length(::Layer)`, forcing users to wrap the layer in `Ref`. This is the standard Julia idiom for marking a struct as a broadcast scalar.

## Scope / safety

- Purely additive: one method plus a docstring.
- A `Vector{Layer}` stack still broadcasts **element-wise** (the desired behavior for per-layer ops); for threaded sweeps the dedicated `sweep_angle` / `sweep_thickness` API remains the recommendation.
- New `@testset "broadcastable Layer"` verifies the bare-layer broadcast works, matches the explicit `Ref(layer)` form, and that `Vector{Layer}` still broadcasts element-wise.

Full test suite (including Aqua) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)