### PR TITLE
Add guide page explaining the transfer matrix elements

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ makedocs(
         "Guide" => Any[
                     "Quick Start" => "guide/quickstart.md",
                     "Tutorial" => "guide/tutorial.md",
+                    "Anatomy of the Transfer Matrix" => "guide/transfer_matrix.md",
                     "Dispersion Models" => "guide/dispersion_models.md",
                     "Physics Validation" => "guide/validation.md"
         ],

--- a/docs/src/assets/transfer_matrix_anisotropic.svg
+++ b/docs/src/assets/transfer_matrix_anisotropic.svg
@@ -1,0 +1,60 @@
+<svg width="680" viewBox="0 0 680 404" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>Anisotropic case: the off-diagonal coupling blocks of M become nonzero</title>
+<desc>The same 4 by 4 M matrix for anisotropic or chiral media. The two diagonal 2x2 blocks (p with p, s with s) give the co-polarized reflection and transmission. The two off-diagonal 2x2 blocks now become nonzero and carry the p-to-s coupling; in particular M13 and M31 drive the cross-polarized transmission t_sp and t_ps, and the determinant gains a cross term d = M11 M33 minus M13 M31, so cross-polarized reflectance and transmittance such as Rps and Rsp turn on.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; fill: #3D3D3A; }
+  .ts { font-size: 12px; font-weight: 400; fill: #6B6A64; }
+  .fig-bg { fill: #FFFFFF; stroke: #E6E4DD; stroke-width: 1; }
+  .box { fill: #F7F6F1; stroke: #D3D1C7; stroke-width: 0.5; }
+  .cell-teal { fill: #E1F5EE; stroke: #5DCAA5; stroke-width: 0.5; }
+  .cell-coral { fill: #FAECE7; stroke: #F0997B; stroke-width: 0.5; }
+  .txt-teal { fill: #0F6E56; }
+  .txt-coral { fill: #712B13; }
+</style>
+
+<rect class="fig-bg" x="1" y="1" width="678" height="402" rx="14"/>
+
+<text class="th" x="40" y="34">Anisotropic case &#8212; the coupling blocks switch on</text>
+<text class="ts" x="40" y="54">p and s no longer separate; the off-diagonal 2&#215;2 blocks carry the p &#8596; s coupling</text>
+
+<text class="ts" x="206" y="84" text-anchor="middle">p+</text>
+<text class="ts" x="284" y="84" text-anchor="middle">p&#8722;</text>
+<text class="ts" x="362" y="84" text-anchor="middle">s+</text>
+<text class="ts" x="440" y="84" text-anchor="middle">s&#8722;</text>
+<text class="ts" x="158" y="125" text-anchor="end">p+</text>
+<text class="ts" x="158" y="181" text-anchor="end">p&#8722;</text>
+<text class="ts" x="158" y="237" text-anchor="end">s+</text>
+<text class="ts" x="158" y="293" text-anchor="end">s&#8722;</text>
+
+<rect class="cell-teal" x="170" y="96" width="72" height="50" rx="4"/><text class="th txt-teal" x="206" y="121" text-anchor="middle" dominant-baseline="central">M&#8321;&#8321;</text>
+<rect class="box" x="248" y="96" width="72" height="50" rx="4"/><text class="th" x="284" y="121" text-anchor="middle" dominant-baseline="central">M&#8321;&#8322;</text>
+<rect class="cell-coral" x="326" y="96" width="72" height="50" rx="4"/><text class="th txt-coral" x="362" y="121" text-anchor="middle" dominant-baseline="central">M&#8321;&#8323;</text>
+<rect class="box" x="404" y="96" width="72" height="50" rx="4"/><text class="th" x="440" y="121" text-anchor="middle" dominant-baseline="central">M&#8321;&#8324;</text>
+
+<rect class="box" x="170" y="152" width="72" height="50" rx="4"/><text class="th" x="206" y="177" text-anchor="middle" dominant-baseline="central">M&#8322;&#8321;</text>
+<rect class="box" x="248" y="152" width="72" height="50" rx="4"/><text class="th" x="284" y="177" text-anchor="middle" dominant-baseline="central">M&#8322;&#8322;</text>
+<rect class="box" x="326" y="152" width="72" height="50" rx="4"/><text class="th" x="362" y="177" text-anchor="middle" dominant-baseline="central">M&#8322;&#8323;</text>
+<rect class="box" x="404" y="152" width="72" height="50" rx="4"/><text class="th" x="440" y="177" text-anchor="middle" dominant-baseline="central">M&#8322;&#8324;</text>
+
+<rect class="cell-coral" x="170" y="208" width="72" height="50" rx="4"/><text class="th txt-coral" x="206" y="233" text-anchor="middle" dominant-baseline="central">M&#8323;&#8321;</text>
+<rect class="box" x="248" y="208" width="72" height="50" rx="4"/><text class="th" x="284" y="233" text-anchor="middle" dominant-baseline="central">M&#8323;&#8322;</text>
+<rect class="cell-teal" x="326" y="208" width="72" height="50" rx="4"/><text class="th txt-teal" x="362" y="233" text-anchor="middle" dominant-baseline="central">M&#8323;&#8323;</text>
+<rect class="box" x="404" y="208" width="72" height="50" rx="4"/><text class="th" x="440" y="233" text-anchor="middle" dominant-baseline="central">M&#8323;&#8324;</text>
+
+<rect class="box" x="170" y="264" width="72" height="50" rx="4"/><text class="th" x="206" y="289" text-anchor="middle" dominant-baseline="central">M&#8324;&#8321;</text>
+<rect class="box" x="248" y="264" width="72" height="50" rx="4"/><text class="th" x="284" y="289" text-anchor="middle" dominant-baseline="central">M&#8324;&#8322;</text>
+<rect class="box" x="326" y="264" width="72" height="50" rx="4"/><text class="th" x="362" y="289" text-anchor="middle" dominant-baseline="central">M&#8324;&#8323;</text>
+<rect class="box" x="404" y="264" width="72" height="50" rx="4"/><text class="th" x="440" y="289" text-anchor="middle" dominant-baseline="central">M&#8324;&#8324;</text>
+
+<rect x="166" y="92" width="158" height="114" rx="7" fill="none" stroke="#1D9E75" stroke-width="1.5"/>
+<rect x="322" y="204" width="158" height="114" rx="7" fill="none" stroke="#1D9E75" stroke-width="1.5"/>
+<rect x="322" y="92" width="158" height="114" rx="7" fill="none" stroke="#D85A30" stroke-width="1.5" stroke-dasharray="5 3"/>
+<rect x="166" y="204" width="158" height="114" rx="7" fill="none" stroke="#D85A30" stroke-width="1.5" stroke-dasharray="5 3"/>
+
+<rect class="cell-teal" x="170" y="334" width="16" height="16" rx="3"/>
+<text class="ts" x="194" y="342" dominant-baseline="central">Diagonal blocks: p&#8594;p, s&#8594;s &#8212; give the co-pol r_pp, t_pp, r_ss, t_ss</text>
+<rect class="cell-coral" x="170" y="358" width="16" height="16" rx="3"/>
+<text class="ts" x="194" y="366" dominant-baseline="central">Coupling blocks: p &#8596; s &#8212; M&#8321;&#8323;, M&#8323;&#8321; drive cross-pol t_sp, t_ps</text>
+<text class="ts" x="40" y="390">Now d = M&#8321;&#8321;M&#8323;&#8323; &#8722; M&#8321;&#8323;M&#8323;&#8321;; the cross term mixes p and s, so cross-pol R/T turn on</text>
+</svg>

--- a/docs/src/assets/transfer_matrix_elements.svg
+++ b/docs/src/assets/transfer_matrix_elements.svg
@@ -1,0 +1,72 @@
+<svg width="680" viewBox="0 0 680 480" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>Significance of each element of the 4x4 transfer matrix M</title>
+<desc>A 4 by 4 grid of elements labeled M i j. Rows are incident-medium plane-wave modes (p and s, forward/incoming and backward/reflected); columns are substrate modes (p and s, forward/transmitted and backward, which is absent). The forward-substrate columns 1 and 3 at the incoming rows form the transmission block whose inverse gives t and whose determinant is d; the same columns at the reflected rows form the reflection block giving r. The backward-substrate columns 2 and 4 are inert because no wave enters from the substrate.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; fill: #3D3D3A; }
+  .ts { font-size: 12px; font-weight: 400; fill: #6B6A64; }
+  .fig-bg { fill: #FFFFFF; stroke: #E6E4DD; stroke-width: 1; }
+  .cell-teal { fill: #E1F5EE; stroke: #5DCAA5; stroke-width: 0.5; }
+  .cell-amber { fill: #FAEEDA; stroke: #EF9F27; stroke-width: 0.5; }
+  .cell-gray { fill: #F1EFE8; stroke: #C9C7BD; stroke-width: 0.5; }
+  .txt-teal { fill: #0F6E56; }
+  .txt-amber { fill: #854F0B; }
+  .txt-gray { fill: #444441; }
+</style>
+
+<rect class="fig-bg" x="1" y="1" width="678" height="478" rx="14"/>
+
+<text class="th" x="40" y="34">Final transfer matrix  M  —  what each element does</text>
+<text class="ts" x="40" y="54">&#968;(incident medium)  =  M &#183; &#968;(substrate)</text>
+
+<text class="ts" x="362" y="82" text-anchor="middle">substrate modes  (columns)</text>
+<text transform="rotate(-90 52 250)" x="52" y="250" class="ts" text-anchor="middle">incident medium  (rows)</text>
+
+<text class="th" x="236" y="100" text-anchor="middle">p &#8594;</text>
+<text class="ts" x="236" y="116" text-anchor="middle">transmitted</text>
+<text class="th" x="320" y="100" text-anchor="middle">p &#8592;</text>
+<text class="ts" x="320" y="116" text-anchor="middle">none</text>
+<text class="th" x="404" y="100" text-anchor="middle">s &#8594;</text>
+<text class="ts" x="404" y="116" text-anchor="middle">transmitted</text>
+<text class="th" x="488" y="100" text-anchor="middle">s &#8592;</text>
+<text class="ts" x="488" y="116" text-anchor="middle">none</text>
+
+<text class="th" x="180" y="155" text-anchor="end">p &#8594;</text>
+<text class="ts" x="180" y="171" text-anchor="end">incoming</text>
+<text class="th" x="180" y="215" text-anchor="end">p &#8592;</text>
+<text class="ts" x="180" y="231" text-anchor="end">reflected</text>
+<text class="th" x="180" y="275" text-anchor="end">s &#8594;</text>
+<text class="ts" x="180" y="291" text-anchor="end">incoming</text>
+<text class="th" x="180" y="335" text-anchor="end">s &#8592;</text>
+<text class="ts" x="180" y="351" text-anchor="end">reflected</text>
+
+<path d="M196 128 H188 V372 H196" fill="none" stroke="#888780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M528 128 H536 V372 H528" fill="none" stroke="#888780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+<rect class="cell-teal" x="196" y="132" width="80" height="56" rx="4"/><text class="th txt-teal" x="236" y="160" text-anchor="middle" dominant-baseline="central">M&#8321;&#8321;</text>
+<rect class="cell-gray" x="280" y="132" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="320" y="160" text-anchor="middle" dominant-baseline="central">M&#8321;&#8322;</text>
+<rect class="cell-teal" x="364" y="132" width="80" height="56" rx="4"/><text class="th txt-teal" x="404" y="160" text-anchor="middle" dominant-baseline="central">M&#8321;&#8323;</text>
+<rect class="cell-gray" x="448" y="132" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="488" y="160" text-anchor="middle" dominant-baseline="central">M&#8321;&#8324;</text>
+
+<rect class="cell-amber" x="196" y="192" width="80" height="56" rx="4"/><text class="th txt-amber" x="236" y="220" text-anchor="middle" dominant-baseline="central">M&#8322;&#8321;</text>
+<rect class="cell-gray" x="280" y="192" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="320" y="220" text-anchor="middle" dominant-baseline="central">M&#8322;&#8322;</text>
+<rect class="cell-amber" x="364" y="192" width="80" height="56" rx="4"/><text class="th txt-amber" x="404" y="220" text-anchor="middle" dominant-baseline="central">M&#8322;&#8323;</text>
+<rect class="cell-gray" x="448" y="192" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="488" y="220" text-anchor="middle" dominant-baseline="central">M&#8322;&#8324;</text>
+
+<rect class="cell-teal" x="196" y="252" width="80" height="56" rx="4"/><text class="th txt-teal" x="236" y="280" text-anchor="middle" dominant-baseline="central">M&#8323;&#8321;</text>
+<rect class="cell-gray" x="280" y="252" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="320" y="280" text-anchor="middle" dominant-baseline="central">M&#8323;&#8322;</text>
+<rect class="cell-teal" x="364" y="252" width="80" height="56" rx="4"/><text class="th txt-teal" x="404" y="280" text-anchor="middle" dominant-baseline="central">M&#8323;&#8323;</text>
+<rect class="cell-gray" x="448" y="252" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="488" y="280" text-anchor="middle" dominant-baseline="central">M&#8323;&#8324;</text>
+
+<rect class="cell-amber" x="196" y="312" width="80" height="56" rx="4"/><text class="th txt-amber" x="236" y="340" text-anchor="middle" dominant-baseline="central">M&#8324;&#8321;</text>
+<rect class="cell-gray" x="280" y="312" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="320" y="340" text-anchor="middle" dominant-baseline="central">M&#8324;&#8322;</text>
+<rect class="cell-amber" x="364" y="312" width="80" height="56" rx="4"/><text class="th txt-amber" x="404" y="340" text-anchor="middle" dominant-baseline="central">M&#8324;&#8323;</text>
+<rect class="cell-gray" x="448" y="312" width="80" height="56" rx="4" stroke-dasharray="3 2"/><text class="th txt-gray" x="488" y="340" text-anchor="middle" dominant-baseline="central">M&#8324;&#8324;</text>
+
+<rect class="cell-teal" x="196" y="394" width="16" height="16" rx="3"/>
+<text class="ts" x="220" y="402" dominant-baseline="central">Transmission block  {M&#8321;&#8321;, M&#8321;&#8323;, M&#8323;&#8321;, M&#8323;&#8323;}  &#8212;  invert for  t,   det = d</text>
+<rect class="cell-amber" x="196" y="420" width="16" height="16" rx="3"/>
+<text class="ts" x="220" y="428" dominant-baseline="central">Reflection block  {M&#8322;&#8321;, M&#8322;&#8323;, M&#8324;&#8321;, M&#8324;&#8323;}  &#8212;  combine with t-block for  r</text>
+<rect class="cell-gray" x="196" y="446" width="16" height="16" rx="3" stroke-dasharray="3 2"/>
+<text class="ts" x="220" y="454" dominant-baseline="central">Inert columns 2 &amp; 4  &#8212;  no wave enters from the substrate (&#215; 0)</text>
+</svg>

--- a/docs/src/assets/transfer_matrix_yeh.svg
+++ b/docs/src/assets/transfer_matrix_yeh.svg
@@ -1,0 +1,60 @@
+<svg width="680" viewBox="0 0 680 400" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>How M's elements map onto Yeh's 2x2 matrix and the bound-mode (BSW) condition</title>
+<desc>In the isotropic limit the 4 by 4 matrix M is block-diagonal: the top-left 2x2 (rows and columns 1 and 2, the p forward and backward modes) and the bottom-right 2x2 (rows and columns 3 and 4, the s modes) are each Yeh's transfer matrix [[A,B],[C,D]]. The A element equals M11 for p and M33 for s; transmission is 1/A and reflection is C/A, so a zero of A marks a bound guided mode such as a Bloch surface wave. The off-diagonal blocks are zero unless the media are anisotropic or chiral.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; fill: #3D3D3A; }
+  .ts { font-size: 12px; font-weight: 400; fill: #6B6A64; }
+  .fig-bg { fill: #FFFFFF; stroke: #E6E4DD; stroke-width: 1; }
+  .box { fill: #F7F6F1; stroke: #D3D1C7; stroke-width: 0.5; }
+  .cell-amber { fill: #FAEEDA; stroke: #EF9F27; stroke-width: 0.5; }
+  .txt-amber { fill: #854F0B; }
+  .leader { stroke: #B4B2A9; stroke-width: 0.5; stroke-dasharray: 3 3; fill: none; }
+</style>
+
+<rect class="fig-bg" x="1" y="1" width="678" height="398" rx="14"/>
+
+<text class="th" x="40" y="34">Relation to Yeh&#8217;s 2&#215;2 transfer matrix</text>
+<text class="ts" x="40" y="54">Isotropic limit: M is block-diagonal; each diagonal 2&#215;2 is Yeh&#8217;s  [[A, B],[C, D]]</text>
+
+<text class="ts" x="206" y="84" text-anchor="middle">p+</text>
+<text class="ts" x="284" y="84" text-anchor="middle">p&#8722;</text>
+<text class="ts" x="362" y="84" text-anchor="middle">s+</text>
+<text class="ts" x="440" y="84" text-anchor="middle">s&#8722;</text>
+<text class="ts" x="158" y="125" text-anchor="end">p+</text>
+<text class="ts" x="158" y="181" text-anchor="end">p&#8722;</text>
+<text class="ts" x="158" y="237" text-anchor="end">s+</text>
+<text class="ts" x="158" y="293" text-anchor="end">s&#8722;</text>
+
+<rect class="cell-amber" x="170" y="96" width="72" height="50" rx="4"/><text class="th txt-amber" x="206" y="114" text-anchor="middle" dominant-baseline="central">M&#8321;&#8321;</text><text class="ts txt-amber" x="206" y="131" text-anchor="middle" dominant-baseline="central">= A</text>
+<rect class="box" x="248" y="96" width="72" height="50" rx="4"/><text class="th" x="284" y="114" text-anchor="middle" dominant-baseline="central">M&#8321;&#8322;</text><text class="ts" x="284" y="131" text-anchor="middle" dominant-baseline="central">= B</text>
+<rect class="box" x="326" y="96" width="72" height="50" rx="4"/><text class="ts" x="362" y="121" text-anchor="middle" dominant-baseline="central">0</text>
+<rect class="box" x="404" y="96" width="72" height="50" rx="4"/><text class="ts" x="440" y="121" text-anchor="middle" dominant-baseline="central">0</text>
+
+<rect class="box" x="170" y="152" width="72" height="50" rx="4"/><text class="th" x="206" y="170" text-anchor="middle" dominant-baseline="central">M&#8322;&#8321;</text><text class="ts" x="206" y="187" text-anchor="middle" dominant-baseline="central">= C</text>
+<rect class="box" x="248" y="152" width="72" height="50" rx="4"/><text class="th" x="284" y="170" text-anchor="middle" dominant-baseline="central">M&#8322;&#8322;</text><text class="ts" x="284" y="187" text-anchor="middle" dominant-baseline="central">= D</text>
+<rect class="box" x="326" y="152" width="72" height="50" rx="4"/><text class="ts" x="362" y="177" text-anchor="middle" dominant-baseline="central">0</text>
+<rect class="box" x="404" y="152" width="72" height="50" rx="4"/><text class="ts" x="440" y="177" text-anchor="middle" dominant-baseline="central">0</text>
+
+<rect class="box" x="170" y="208" width="72" height="50" rx="4"/><text class="ts" x="206" y="233" text-anchor="middle" dominant-baseline="central">0</text>
+<rect class="box" x="248" y="208" width="72" height="50" rx="4"/><text class="ts" x="284" y="233" text-anchor="middle" dominant-baseline="central">0</text>
+<rect class="cell-amber" x="326" y="208" width="72" height="50" rx="4"/><text class="th txt-amber" x="362" y="226" text-anchor="middle" dominant-baseline="central">M&#8323;&#8323;</text><text class="ts txt-amber" x="362" y="243" text-anchor="middle" dominant-baseline="central">= A</text>
+<rect class="box" x="404" y="208" width="72" height="50" rx="4"/><text class="th" x="440" y="226" text-anchor="middle" dominant-baseline="central">M&#8323;&#8324;</text><text class="ts" x="440" y="243" text-anchor="middle" dominant-baseline="central">= B</text>
+
+<rect class="box" x="170" y="264" width="72" height="50" rx="4"/><text class="ts" x="206" y="289" text-anchor="middle" dominant-baseline="central">0</text>
+<rect class="box" x="248" y="264" width="72" height="50" rx="4"/><text class="ts" x="284" y="289" text-anchor="middle" dominant-baseline="central">0</text>
+<rect class="box" x="326" y="264" width="72" height="50" rx="4"/><text class="th" x="362" y="282" text-anchor="middle" dominant-baseline="central">M&#8324;&#8323;</text><text class="ts" x="362" y="299" text-anchor="middle" dominant-baseline="central">= C</text>
+<rect class="box" x="404" y="264" width="72" height="50" rx="4"/><text class="th" x="440" y="282" text-anchor="middle" dominant-baseline="central">M&#8324;&#8324;</text><text class="ts" x="440" y="299" text-anchor="middle" dominant-baseline="central">= D</text>
+
+<rect x="166" y="92" width="158" height="114" rx="7" fill="none" stroke="#1D9E75" stroke-width="1.5"/>
+<rect x="322" y="204" width="158" height="114" rx="7" fill="none" stroke="#378ADD" stroke-width="1.5"/>
+<text class="ts" x="512" y="149">p block</text>
+<text class="ts" x="512" y="261">s block</text>
+<line class="leader" x1="324" y1="149" x2="506" y2="149"/>
+<line class="leader" x1="480" y1="261" x2="506" y2="261"/>
+
+<rect class="cell-amber" x="170" y="334" width="16" height="16" rx="3"/>
+<text class="th" x="194" y="342" dominant-baseline="central">A element (M&#8321;&#8321; for p, M&#8323;&#8323; for s):   t = 1/A,   r = C/A</text>
+<text class="ts" x="40" y="366">A &#8594; 0 (with fields evanescent on both sides) is a guided mode / Bloch surface wave</text>
+<text class="ts" x="40" y="386">Off-diagonal blocks (the 0 s) couple p &#8596; s &#8212; nonzero only for anisotropic / chiral media</text>
+</svg>

--- a/docs/src/guide/transfer_matrix.md
+++ b/docs/src/guide/transfer_matrix.md
@@ -1,0 +1,153 @@
+# Anatomy of the transfer matrix
+
+The method collapses an entire layered stack into a single ``4\times4`` matrix,
+and every reflectance and transmittance number is read straight off it. This
+page explains what that matrix is and what each of its elements means.
+
+[`transfer`](@ref) returns a [`TransferResult`](@ref) of ``R``/``T`` values; the
+matrix itself is the first item returned by the internal `TransferMatrix.propagate`:
+
+```julia
+M, S, Ds, Ps, γs = TransferMatrix.propagate(1.0, layers; θ=0.3)
+M  # the 4×4 complex transfer matrix for the whole stack
+```
+
+!!! note "A note on the symbol"
+    This page calls the final transfer matrix ``M``, matching Yeh (1979), whose
+    per-polarization ``2\times2`` matrix is the building block we map onto below.
+    The source code calls the same object ``\Gamma`` (specifically ``\Gamma^*``
+    after reordering into Yeh's field convention) — it is the same matrix.
+
+## What the matrix represents
+
+``M`` connects the four plane-wave mode amplitudes on the two sides of the stack:
+
+```math
+\psi_\text{inc} = M\,\psi_\text{sub},
+\qquad
+\psi = \begin{pmatrix} p^{+} \\ p^{-} \\ s^{+} \\ s^{-} \end{pmatrix},
+```
+
+where ``+`` is the forward (``+z``) mode and ``-`` the backward (``-z``) mode of
+each polarization. **Rows** index modes in the incident medium; **columns**
+index modes in the substrate. On the incident side the forward modes are the
+*incoming* wave and the backward modes are the *reflected* wave; on the substrate
+side the forward modes are the *transmitted* wave and the backward modes are
+absent — nothing illuminates the stack from behind.
+
+![The 4×4 transfer matrix with each element's role: transmission block, reflection block, and the inert backward-substrate columns.](../assets/transfer_matrix_elements.svg)
+
+## Which elements carry the physics
+
+Because the backward-substrate amplitudes are zero, **columns 2 and 4 multiply
+zero and never affect an observable** — only columns 1 and 3 act. The active
+elements split into two blocks.
+
+**Transmission block** — rows ``\{1,3\}`` × columns ``\{1,3\}``. Its determinant
+is the shared denominator, and its inverse is the transmission Jones matrix:
+
+```math
+d = M_{11}M_{33} - M_{13}M_{31},
+```
+```math
+t_{pp} = \frac{M_{33}}{d}, \quad
+t_{ss} = \frac{M_{11}}{d}, \quad
+t_{ps} = -\frac{M_{31}}{d}, \quad
+t_{sp} = -\frac{M_{13}}{d}.
+```
+
+**Reflection block** — rows ``\{2,4\}`` × columns ``\{1,3\}``, read out against
+the same transmission block:
+
+```math
+\begin{aligned}
+r_{pp} &= \frac{M_{21}M_{33} - M_{23}M_{31}}{d}, &
+r_{ss} &= \frac{M_{11}M_{43} - M_{41}M_{13}}{d}, \\[4pt]
+r_{ps} &= \frac{M_{41}M_{33} - M_{43}M_{31}}{d}, &
+r_{sp} &= \frac{M_{11}M_{23} - M_{21}M_{13}}{d}.
+\end{aligned}
+```
+
+Reflectance is then ``R = |r|^2`` directly, while transmittance ``T`` is a
+Poynting-vector flux ratio rather than ``|t|^2`` (the transmitted wave lives in a
+different medium) — see [Physics Validation](validation.md). These formulas are exactly
+what [`calculate_tr`](@ref) evaluates.
+
+The full ``16``-element map:
+
+| Element | incident mode (row) | substrate mode (col) | appears in |
+|:--|:--|:--|:--|
+| ``M_{11}`` | ``p^{+}`` incoming  | ``p^{+}`` transmitted | ``d``, ``t_{ss}``, ``r_{ss}``, ``r_{sp}`` |
+| ``M_{12}`` | ``p^{+}`` incoming  | ``p^{-}`` (absent) | — inert |
+| ``M_{13}`` | ``p^{+}`` incoming  | ``s^{+}`` transmitted | ``d``, ``t_{sp}``, ``r_{ss}``, ``r_{sp}`` |
+| ``M_{14}`` | ``p^{+}`` incoming  | ``s^{-}`` (absent) | — inert |
+| ``M_{21}`` | ``p^{-}`` reflected | ``p^{+}`` transmitted | ``r_{pp}``, ``r_{sp}`` |
+| ``M_{22}`` | ``p^{-}`` reflected | ``p^{-}`` (absent) | — inert |
+| ``M_{23}`` | ``p^{-}`` reflected | ``s^{+}`` transmitted | ``r_{pp}``, ``r_{sp}`` |
+| ``M_{24}`` | ``p^{-}`` reflected | ``s^{-}`` (absent) | — inert |
+| ``M_{31}`` | ``s^{+}`` incoming  | ``p^{+}`` transmitted | ``d``, ``t_{ps}``, ``r_{pp}``, ``r_{ps}`` |
+| ``M_{32}`` | ``s^{+}`` incoming  | ``p^{-}`` (absent) | — inert |
+| ``M_{33}`` | ``s^{+}`` incoming  | ``s^{+}`` transmitted | ``d``, ``t_{pp}``, ``r_{pp}``, ``r_{ps}`` |
+| ``M_{34}`` | ``s^{+}`` incoming  | ``s^{-}`` (absent) | — inert |
+| ``M_{41}`` | ``s^{-}`` reflected | ``p^{+}`` transmitted | ``r_{ps}``, ``r_{ss}`` |
+| ``M_{42}`` | ``s^{-}`` reflected | ``p^{-}`` (absent) | — inert |
+| ``M_{43}`` | ``s^{-}`` reflected | ``s^{+}`` transmitted | ``r_{ps}``, ``r_{ss}`` |
+| ``M_{44}`` | ``s^{-}`` reflected | ``s^{-}`` (absent) | — inert |
+
+## Isotropic limit: Yeh's 2×2 matrices
+
+The field ordering ``(p^{+}, p^{-}, s^{+}, s^{-})`` keeps the two p-modes adjacent
+and the two s-modes adjacent. So for isotropic (or optic-axis-aligned) media,
+where p and s do not mix, ``M`` is **block-diagonal**, and each diagonal
+``2\times2`` block *is* Yeh's transfer matrix for that polarization:
+
+```math
+\begin{pmatrix} A & B \\ C & D \end{pmatrix},
+\qquad A = M_{11}\ (\text{p}), \quad A = M_{33}\ (\text{s}).
+```
+
+With no backward wave in the substrate, Yeh's relation gives ``t = 1/A`` and
+``r = C/A`` — which is exactly the block formulas above specialized to
+``M_{13}=M_{31}=0`` (so ``d = M_{11}M_{33}``, ``t_{pp}=1/M_{11}``,
+``r_{pp}=M_{21}/M_{11}``, and likewise for s).
+
+![In the isotropic limit M is block-diagonal; each diagonal 2×2 is Yeh's A B C D matrix, with A = M₁₁ for p and M₃₃ for s.](../assets/transfer_matrix_yeh.svg)
+
+### Bound modes and Bloch surface waves
+
+A guided (bound) mode is a **pole of ``r`` and ``t``** — a self-sustaining field
+with *no* incident wave — i.e. the denominator vanishes. In the decoupled case
+that is ``A = 0``: ``M_{11}=0`` for a p-polarized mode, ``M_{33}=0`` for an
+s-polarized mode (in the full coupled problem it generalizes to ``d=0``).
+
+A **Bloch surface wave** (BSW) is the bound mode at the truncation of a periodic
+multilayer (e.g. a DBR). It lives inside a photonic band gap of the stack — so it
+decays into the periodic side — and below the light line of the outer cladding —
+so it decays into the cladding. To find one with this package:
+
+1. Use a high-index coupling prism as the incident (first) layer so that the
+   in-plane wavevector ``\beta = k_0\,\xi`` can exceed the cladding light line.
+2. Scan angle/wavelength with [`sweep_angle`](@ref) past the critical angle; the
+   BSW appears as a sharp dip in the reflectance (``R_{pp}`` or ``R_{ss}``) where
+   ``A`` passes through its zero.
+3. Confirm it with [`efield`](@ref): the field is localized and strongly enhanced
+   at the truncation surface.
+
+## Anisotropic and chiral media
+
+When the media are anisotropic or chiral, p and s couple and the **off-diagonal
+blocks switch on**. The elements ``M_{13}`` and ``M_{31}`` drive the
+cross-polarized transmission (``t_{sp} = -M_{13}/d``, ``t_{ps} = -M_{31}/d``),
+and the determinant picks up the cross term:
+
+```math
+d = M_{11}M_{33} - M_{13}M_{31}.
+```
+
+That cross term ties the p and s poles together, so a bound mode at ``d = 0`` is
+generally a **mixed-polarization** surface mode rather than a pure p or s one.
+The cross-polarization observables ``R_{ps}, R_{sp}, T_{ps}, T_{sp}`` — exactly
+zero for isotropic media — become nonzero; this same coupling is what the
+[Circular-polarization basis](tutorial.md#Circular-polarization-basis) output reflects.
+
+![For anisotropic or chiral media the off-diagonal coupling blocks of M become nonzero; M₁₃ and M₃₁ drive the cross-polarization terms.](../assets/transfer_matrix_anisotropic.svg)


### PR DESCRIPTION
Adds a new Guide page, **Anatomy of the transfer matrix**, explaining what the final 4×4 transfer matrix `M` is and the significance of each of its elements.

## Contents
- **What the matrix represents** — `ψ_inc = M·ψ_sub` in the `(p⁺, p⁻, s⁺, s⁻)` basis; rows = incident modes, columns = substrate modes.
- **Which elements carry the physics** — the inert backward-substrate columns (2 & 4), the transmission block + determinant `d`, the reflection block, and a full 16-element reference table.
- **Isotropic limit → Yeh's 2×2** — `M` is block-diagonal and each diagonal block is Yeh's `A/B/C/D` matrix; `A = M₁₁/M₃₃`, `t = 1/A`, `r = C/A`, with the `A = 0` bound-mode / Bloch-surface-wave condition and a practical find-it recipe.
- **Anisotropic / chiral media** — the off-diagonal coupling blocks switch on; `M₁₃, M₃₁` drive cross-polarization and the determinant gains a cross term.

The `r/t/d` formulas and the element table are consistent with `calculate_tr`. Three self-contained SVG schematics (light-card styling, legible in both Documenter themes) are added under `docs/src/assets/`, and the page is wired into the Guide nav in `docs/make.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)