### PR TITLE
docs: fix broken bibliography link on the homepage

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ TransferMatrix.jl provides a general 4x4 transfer matrix method for optical wave
 The core is an electrodynamics simulation based on a general 4x4 transfer matrix method developed by Passler, et al.
 Recent corrections and improvements are incorporated to deal with singularities and numerical instabilities for some types of multi-layered structures.
 Sources are cited both in the documentation and docstrings where appropriate.
-A comprehensive [bibliography](https://garrek.org/TransferMatrix.jl/stable/bibliography/) is also available as part of the documentation.
+A comprehensive [bibliography](bibliography.md) is also available as part of the documentation.
 
 There are a lot of transfer matrix programs out there. Many are
 proprietary and some are part of graduate theses. The problem


### PR DESCRIPTION
The homepage (`docs/src/index.md`) linked the bibliography via an absolute `garrek.org` URL, but that domain isn't configured for GitHub Pages (`cname` is unset), so the link 404s. Switched it to a relative intra-doc link (`bibliography.md`), which Documenter resolves to the correct page on both the `dev` and `stable` builds and which survives any future domain change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)