### PR TITLE
docs: reframe method attribution from Passler to multi-formalism synthesis

### DIFF
--- a/docs/src/bibliography.md
+++ b/docs/src/bibliography.md
@@ -19,7 +19,7 @@ All references used for writing TransferMatrix.jl.
 References supporting the modeling of a 2D material / TMDC monolayer as a surface
 optical conductivity sheet (the `Sheet` type, `sheet_matrix`, and the
 refractive-index ↔ sheet-conductivity conversion). The oblique-incidence,
-anisotropic 4×4 interface matrix used in the code follows the Berreman/Passler
+anisotropic 4×4 interface matrix used in the code follows the Berreman
 formalism above; the surface-conductivity boundary condition and the
 `σ_s = -iωε₀d(n²-1)` conversion follow [10] and [11].
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,20 +1,10 @@
 # TransferMatrix.jl
 
 TransferMatrix.jl provides a general 4x4 transfer matrix method for optical waves propagating in layered media implemented in Julia.
-The core is an electrodynamics simulation based on a general 4x4 transfer matrix method developed by Passler, et al.
-Recent corrections and improvements are incorporated to deal with singularities and numerical instabilities for some types of multi-layered structures.
+The core is an electrodynamics simulation built on the 4x4 transfer-matrix formalism for stratified, anisotropic media — rooted in Berreman's original matrix formulation and the refinements developed since, including Yeh's treatment of birefringent layers and Xu et al.'s singularity-free eigenmode handling.
+Further corrections and improvements deal with singularities and numerical instabilities that arise for some multi-layered structures.
 Sources are cited both in the documentation and docstrings where appropriate.
 A comprehensive [bibliography](bibliography.md) is also available as part of the documentation.
-
-There are a lot of transfer matrix programs out there. Many are
-proprietary and some are part of graduate theses. The problem
-with the proprietary ones are that the source code cannot be examined 
-nor modified (and are not free). The problem with programs 
-written for papers are that they are rarely maintained, are not
-well documented, are not well tested, and are poorly organized.
-This makes it very difficult to use them. TransferMatrix.jl 
-solves these problems and provides the first generalized 4x4 transfer matrix algorithm
-available for Julia.
 
 ```@raw html
 <div style="text-align: center;">

--- a/src/general_TMM.jl
+++ b/src/general_TMM.jl
@@ -526,16 +526,27 @@ end
 """
     calculate_tr(Γ)
 
-Calculate reflectance and transmittance for the total stack.
-This takes the matrix Γ* in Passler, et al., but for brevity we call it Γ in this function.
+Read the reflection and transmission coefficients off the full-stack transfer
+matrix `Γ`.
 
-The original formalism is from:
-Yeh, 1979,
-https://doi.org/10.1364/JOSA.69.000742
+`Γ` is the ``4\\times4`` transfer matrix for the whole stack, reordered into the
+p/s block convention (the two p modes first, then the two s modes) so the
+reflection and transmission Jones blocks can be read straight off its elements —
+the matrix Passler & Paarmann write as ``Γ^*``. The function returns the co- and
+cross-polarized amplitude coefficients (`rpp, rss, rps, rsp`, `tpp, tss, tps,
+tsp`) and their squared magnitudes.
 
-but the ordering of reflection/transmission coefficients 
-is modified in Passler, et al. 2017
-https://doi.org/10.1364/JOSAB.34.002128
+Reflectance is ``R = |r|^2`` directly. The returned ``|t|^2`` is *not* the
+physical transmittance — the transmitted wave is in a different medium — so the
+diagonal `Tpp`/`Tss` reported by `transfer` come from the Poynting-vector
+calculation (`calculate_tr(S::Poynting)`) instead.
+
+The ``2\\times2`` transfer-matrix relations originate with Yeh (1979); the
+generalized ``4\\times4`` coefficient formulas follow Passler & Paarmann (2017).
+
+References:
+- Yeh, 1979, https://doi.org/10.1364/JOSA.69.000742
+- Passler & Paarmann, 2017, https://doi.org/10.1364/JOSAB.34.002128
 """
 function calculate_tr(Γ)
 


### PR DESCRIPTION
## Summary

The homepage credited the entire 4×4 transfer matrix method to Passler et al. This reframes it as a synthesis of several formalisms — Berreman's original matrix formulation, Yeh's birefringent-layer treatment, and Xu et al.'s singularity-free eigenmode handling. **Passler & Paarmann remain credited** in the bibliography and in the per-equation docstring citations; only the blanket method-level attribution in prose is removed.

## Changes
- `docs/src/index.md` — reframe the opening paragraph; remove the second paragraph (the "first generalized 4×4 algorithm for Julia" block, a contestable claim).
- `docs/src/bibliography.md` — sheet note "Berreman/Passler formalism" → "Berreman formalism".
- `src/general_TMM.jl` — rewrite the `calculate_tr(Γ)` docstring: explain that Γ is the reordered full-stack matrix, drop the muddled "ordering … is modified" line, note that |t|² is not the physical transmittance (Poynting supersedes it), and keep the accurate Yeh + Passler citations.

## Verification
- `Pkg.test()` — full suite passes.
- Package precompiles; the rewritten docstring renders and the `@ref` to `calculate_tr` still resolves.
- Passler now appears in `docs/` only in bibliography citations; no "developed by" method attribution remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)